### PR TITLE
Migrate Auth and User to requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.python-version
 *.pyc

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+Contributors to this project:
+
+- mgp25 <me@mgp25.com>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 Contributors to this project:
 
 - mgp25 <me@mgp25.com>
+- aurynn shaw <self@aurynn.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017, per CONTRUBTORS.md
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Auth.py
+++ b/src/Auth.py
@@ -4,6 +4,13 @@ import urllib.request
 import urllib.parse
 import os
 
+
+# Global IDs
+LOGIN_CLIENT_ID = '71a7beb8-f21a-47d9-a604-2e71bee24fe0'
+CLIENT_ID       = "b7cbf451-6bb6-4a5a-8913-71e61f462787"
+DUID            = "0000000d000400808F4B3AA3301B4945B2E3636E38C0DDFC"
+CLIENT_SECRET   = "zsISsjmCx85zgCJg"
+
 class Auth:
 
     oauth = None
@@ -21,34 +28,34 @@ class Auth:
                         "authentication_type": 'password',
                         "username": None,
                         'password': None,
-                        'client_id': '71a7beb8-f21a-47d9-a604-2e71bee24fe0'
+                        'client_id': LOGIN_CLIENT_ID
                     }
 
     oauth_request = {
                         "app_context": "inapp_ios",
-                        "client_id": "b7cbf451-6bb6-4a5a-8913-71e61f462787",
-                        "client_secret": "zsISsjmCx85zgCJg",
+                        "client_id": CLIENT_ID,
+                        "client_secret": CLIENT_SECRET,
                         "code": None,
-                        "duid": "0000000d000400808F4B3AA3301B4945B2E3636E38C0DDFC",
+                        "duid": DUID,
                         "grant_type": "authorization_code",
                         "scope": "capone:report_submission,psn:sceapp,user:account.get,user:account.settings.privacy.get,user:account.settings.privacy.update,user:account.realName.get,user:account.realName.update,kamaji:get_account_hash,kamaji:ugc:distributor,oauth:manage_device_usercodes"
                     }
 
     code_request = {
                         "state": "06d7AuZpOmJAwYYOWmVU63OMY",
-                        "duid": "0000000d000400808F4B3AA3301B4945B2E3636E38C0DDFC",
+                        "duid": DUID,
                         "app_context": "inapp_ios",
-                        "client_id": "b7cbf451-6bb6-4a5a-8913-71e61f462787",
+                        "client_id": CLIENT_ID,
                         "scope": "capone:report_submission,psn:sceapp,user:account.get,user:account.settings.privacy.get,user:account.settings.privacy.update,user:account.realName.get,user:account.realName.update,kamaji:get_account_hash,kamaji:ugc:distributor,oauth:manage_device_usercodes",
                         "response_type": "code"
                     }
 
     refresh_oauth_request = {
                                 "app_context": "inapp_ios",
-                                "client_id": "b7cbf451-6bb6-4a5a-8913-71e61f462787",
-                                "client_secret": "zsISsjmCx85zgCJg",
+                                "client_id": CLIENT_ID,
+                                "client_secret": CLIENT_SECRET,
                                 "refresh_token": None,
-                                "duid": "0000000d000400808F4B3AA3301B4945B2E3636E38C0DDFC",
+                                "duid": DUID,
                                 "grant_type": "refresh_token",
                                 "scope": "capone:report_submission,psn:sceapp,user:account.get,user:account.settings.privacy.get,user:account.settings.privacy.update,user:account.realName.get,user:account.realName.update,kamaji:get_account_hash,kamaji:ugc:distributor,oauth:manage_device_usercodes"
                             }
@@ -57,7 +64,7 @@ class Auth:
                                 "authentication_type": "two_step",
                                 "ticket_uuid": None,
                                 "code": None,
-                                "client_id": "b7cbf451-6bb6-4a5a-8913-71e61f462787",
+                                "client_id": CLIENT_ID,
                               }
 
     def __init__(self, email, password, ticket='', code=''):
@@ -122,10 +129,10 @@ class Auth:
     def GrabNewTokens(refreshToken):
         refresh_oauth_request = {
             "app_context": "inapp_ios",
-            "client_id": "b7cbf451-6bb6-4a5a-8913-71e61f462787",
-            "client_secret": "zsISsjmCx85zgCJg",
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
             "refresh_token": None,
-            "duid": "0000000d000400808F4B3AA3301B4945B2E3636E38C0DDFC",
+            "duid": DUID,
             "grant_type": "refresh_token",
             "scope": "capone:report_submission,psn:sceapp,user:account.get,user:account.settings.privacy.get,user:account.settings.privacy.update,user:account.realName.get,user:account.realName.update,kamaji:get_account_hash,kamaji:ugc:distributor,oauth:manage_device_usercodes"
         }
@@ -133,7 +140,7 @@ class Auth:
         refresh_oauth_request['refresh_token'] = refreshToken
 
         data = urllib.parse.urlencode(refresh_oauth_request).encode('utf-8')
-        request = urllib.request.Request('https://auth.api.sonyentertainmentnetwork.com/2.0/oauth/token', data = data)
+        request = urllib.request.Request(self.OAUTH_URL, data = data)
         response = urllib.request.urlopen(request)
         data = json.loads(response.read().decode('utf-8'))
 

--- a/src/User.py
+++ b/src/User.py
@@ -1,8 +1,5 @@
-import simplejson
-import json
-import urllib.request
-import urllib.parse
-import os
+import requests
+from urllib.parse import urljoin
 
 class User:
 
@@ -19,11 +16,11 @@ class User:
         header = {
             'Authorization': 'Bearer '+self.oauth
         }
+        endpoint = '?fields=npId,onlineId,avatarUrls,plus,aboutMe,languagesUsed,trophySummary(@default,progress,earnedTrophies),isOfficiallyVerified,personalDetail(@default,profilePictureUrls),personalDetailSharing,personalDetailSharingRequestMessageFlag,primaryOnlineStatus,presences(@titleInfo,hasBroadcastData),friendRelation,requestMessageFlag,blocking,mutualFriendsCount,following,followerCount,friendsCount,followingUsersCount&avatarSizes=m,xl&profilePictureSizes=m,xl&languagesUsedLanguageSet=set3&psVitaTitleIcon=circled&titleIconSize=s'
+        
+        url = urljoin(self.USERS_URL, "me/profile2")
+        url = urljoin(url, endpoint)
+        
+        response = requests.get(url=url,headers=header)
 
-        endpoint = 'me/profile2?fields=npId,onlineId,avatarUrls,plus,aboutMe,languagesUsed,trophySummary(@default,progress,earnedTrophies),isOfficiallyVerified,personalDetail(@default,profilePictureUrls),personalDetailSharing,personalDetailSharingRequestMessageFlag,primaryOnlineStatus,presences(@titleInfo,hasBroadcastData),friendRelation,requestMessageFlag,blocking,mutualFriendsCount,following,followerCount,friendsCount,followingUsersCount&avatarSizes=m,xl&profilePictureSizes=m,xl&languagesUsedLanguageSet=set3&psVitaTitleIcon=circled&titleIconSize=s'
-
-        request = urllib.request.Request(self.USERS_URL+endpoint, headers=header)
-        response = urllib.request.urlopen(request)
-        data = json.loads(response.read().decode('utf-8'))
-
-        return data
+        return response.json()


### PR DESCRIPTION
Migrates all of Auth and User to use Requests instead of direct `urlopen` or shelling out to `curl`.

Adds an `nsppo=""` to the auth creation flow, because I was getting captcha errors, so this allows pulling the nsppo code out of the browser cookies.